### PR TITLE
Made heading field required for web notifications

### DIFF
--- a/app/bundles/NotificationBundle/Form/Type/NotificationType.php
+++ b/app/bundles/NotificationBundle/Form/Type/NotificationType.php
@@ -73,7 +73,7 @@ class NotificationType extends AbstractType
                 'label'      => 'mautic.notification.form.heading',
                 'label_attr' => ['class' => 'control-label'],
                 'attr'       => ['class' => 'form-control'],
-                'required'   => false,
+                'required'   => true,
             ]
         );
 


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: Push notifications have a NOT NULL DB constraint on heading column, but UX does not require heading to be filled in. Saving a new push notification without a heading causes a DB constraint error and fails.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. In Campaign Builder, add a new Send Marketing Message action
2. Under Select Marketing Message, choose Create New
3. Select Mobile Notification, and click enable
4. Select Create New
5. Enter required fields, select Save

#### Steps to test this PR:
1. Same as above

#### List deprecations along with the new alternative:
1. N/A

#### List backwards compatibility breaks:
1. N/A